### PR TITLE
Fix Turbo API call in language controller

### DIFF
--- a/app/javascript/controllers/language_controller.js
+++ b/app/javascript/controllers/language_controller.js
@@ -13,6 +13,6 @@ export default class extends Controller {
     const form = this.formTarget
     const url = new URL(form.action)
     url.searchParams.set("locale", this.switchTarget.checked ? "lv" : "en")
-    window.Turbo.visit(url.toString())
+    Turbo.visit(url.toString())
   }
 }


### PR DESCRIPTION
Fixes console error by changing `window.Turbo.visit()` to `Turbo.visit()` to use the correct Turbo API.