### PR TITLE
Fix game session form to be closed by default

### DIFF
--- a/app/assets/stylesheets/game_sessions.css
+++ b/app/assets/stylesheets/game_sessions.css
@@ -42,6 +42,7 @@
 
 /* Form wrapper for slide-down effect */
 #new-game-session-form-wrapper {
+  max-height: 0;
   overflow: hidden;
   transition: max-height 0.4s ease;
 }

--- a/app/javascript/controllers/game_session_controller.js
+++ b/app/javascript/controllers/game_session_controller.js
@@ -5,7 +5,10 @@ export default class extends Controller {
   static values = { hasErrors: Boolean }
 
   connect() {
-    if (this.hasErrorsValue) {
+    // Initialize form as closed
+    if (!this.hasErrorsValue) {
+      this.formWrapperTarget.style.maxHeight = "0"
+    } else {
       this.openForm()
     }
   }


### PR DESCRIPTION
Fixes the issue where the new game session form was open by default on page load.

**Changes:**
- Added `max-height: 0` to CSS to start form collapsed
- Updated JS controller to explicitly initialize form as closed
- Form only opens when button is clicked or validation errors exist