### PR TITLE
Fix duplicate data attribute in language switcher form

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -12,7 +12,7 @@
   </div>
   <div class="language-switcher-wrapper" data-controller="language">
     <span class="language-label">EN</span>
-    <%= form_with url: url_for(locale: I18n.locale == :en ? :lv : :en), method: :get, data: { turbo: true }, id: "language-switch-form", data: { language_target: "form" } do %>
+    <%= form_with url: url_for(locale: I18n.locale == :en ? :lv : :en), method: :get, id: "language-switch-form", data: { turbo: true, language_target: "form" } do %>
       <label class="switch">
         <input type="checkbox"
               id="language-switch"


### PR DESCRIPTION
Fixes Ruby warning about duplicate `data` key in the language switcher form.

**Changes:**
- Combined two separate `data` attributes into a single hash
- Eliminates warning: `key :data is duplicated and overwritten on line 15`

All tests pass with no warnings.